### PR TITLE
Group Permissions via `umask 002`

### DIFF
--- a/src/bacon/install.sh
+++ b/src/bacon/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall bacon --locked -y

--- a/src/cargo-audit/install.sh
+++ b/src/cargo-audit/install.sh
@@ -14,4 +14,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall cargo-audit --locked -y

--- a/src/cargo-binstall/install.sh
+++ b/src/cargo-binstall/install.sh
@@ -20,4 +20,5 @@ if [ -z "${PACKAGES}" ]; then
     exit 0
 fi
 
+umask 002
 cargo binstall -y --force --locked $CARGO_PACKAGES

--- a/src/cargo-bundle/install.sh
+++ b/src/cargo-bundle/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall cargo-bundle --locked -y

--- a/src/cargo-deny/install.sh
+++ b/src/cargo-deny/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall cargo-deny --locked -y

--- a/src/cargo-expand/install.sh
+++ b/src/cargo-expand/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall cargo-expand --locked -y

--- a/src/cargo-make/install.sh
+++ b/src/cargo-make/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall cargo-make --locked -y

--- a/src/cargo-mobile/install.sh
+++ b/src/cargo-mobile/install.sh
@@ -9,4 +9,5 @@ fi
 
 dpkg -l | grep build-essential || (apt update && apt install build-essential -y -qq)
 
+umask 002
 cargo install --git https://github.com/BrainiumLLC/cargo-mobile

--- a/src/cargo-nextest/install.sh
+++ b/src/cargo-nextest/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall cargo-nextest --locked -y

--- a/src/cargo-watch/install.sh
+++ b/src/cargo-watch/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall cargo-watch --locked -y

--- a/src/cargo-web/install.sh
+++ b/src/cargo-web/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall cargo-web --locked -y

--- a/src/dexterous_developer/install.sh
+++ b/src/dexterous_developer/install.sh
@@ -17,6 +17,7 @@ fi
 
 apt install -y g++ pkg-config libx11-dev libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev clang lld mold
 
+umask 002
 cargo binstall dexterous_developer_cli --locked -y
 
 rustup default nightly

--- a/src/dioxus/install.sh
+++ b/src/dioxus/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall dioxus-cli --locked -y

--- a/src/helix/install.sh
+++ b/src/helix/install.sh
@@ -14,4 +14,5 @@ dpkg -l | grep "ii  git" || (apt update && apt install git -y -qq)
 
 git clone https://github.com/helix-editor/helix
 cd helix
+umask 002
 cargo install --path helix-term --locked

--- a/src/honggfuzz/install.sh
+++ b/src/honggfuzz/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall honggfuzz --locked -y

--- a/src/mprocs/install.sh
+++ b/src/mprocs/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall mprocs --locked -y

--- a/src/rust_windows_msvc/install.sh
+++ b/src/rust_windows_msvc/install.sh
@@ -14,6 +14,7 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
 fi
 
 rustup target add x86_64-pc-windows-msvc
+umask 002
 cargo install xwin
 
 xwin --accept-license splat --output /.xwin

--- a/src/sccache/install.sh
+++ b/src/sccache/install.sh
@@ -13,6 +13,7 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall sccache --locked -y
 
 mkdir /.cargo

--- a/src/wasm-bindgen-cli/install.sh
+++ b/src/wasm-bindgen-cli/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall wasm-bindgen-cli --locked -y

--- a/src/wasm-server-runner/install.sh
+++ b/src/wasm-server-runner/install.sh
@@ -9,4 +9,5 @@ fi
 
 dpkg -l | grep build-essential || (apt update && apt install build-essential -y -qq)
 
+umask 002
 cargo install wasm-server-runner -f

--- a/src/wasmcloud/install.sh
+++ b/src/wasmcloud/install.sh
@@ -20,5 +20,6 @@ make
 make test
 make install
 
+umask 002
 cargo install wash-cli --git https://github.com/wasmcloud/wash --force
 

--- a/src/zellij/install.sh
+++ b/src/zellij/install.sh
@@ -13,4 +13,5 @@ if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
+umask 002
 cargo binstall zellij --locked -y

--- a/test/_global/ensure_rustlang_group.sh
+++ b/test/_global/ensure_rustlang_group.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+function testgroup() {
+    local groupname="$1"
+    local filename="$2"
+    test "$(stat --printf '%G' ${filename})" = "$groupname"
+}
+
+# text for g=rwx
+function test_directory_perms() {
+    local filename="$1"
+    local permissions="$(stat --printf '%05a' $filename)"
+    ((("$permissions" & 070) == 070))
+}
+
+source dev-container-features-test-lib
+
+check 'rustlang group exists'                    grep ^rustlang /etc/group
+check '$CARGO_HOME/registry/: group is set'      testgroup rustlang   $CARGO_HOME/registry
+check '$CARGO_HOME/registry/: group permissions' test_directory_perms $CARGO_HOME/registry
+
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -1,0 +1,10 @@
+{
+    "ensure_rustlang_group": {
+        "image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+        "features": {
+            "bacon": {},
+            "cargo-binstall": {},
+            "cargo-watch": {}
+        }
+    }
+}


### PR DESCRIPTION
Highly simplified change to set `umask 002` before any usage of `cargo binstall` or `cargo install`.