### PR TITLE
fix binstall usage

### DIFF
--- a/src/rust_windows_msvc/install.sh
+++ b/src/rust_windows_msvc/install.sh
@@ -9,15 +9,15 @@ fi
 
 dpkg -l | grep build-essential || (apt update && apt install build-essential -y -qq)
 
-
-
 rustup target add x86_64-pc-windows-msvc
-if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
-    cargo install cargo-binstall
-fi
 
 umask 002
-cargo install xwin
+
+if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
+    cargo install xwin
+else
+    cargo binstall xwin
+fi
 
 xwin --accept-license splat --output /.xwin
 


### PR DESCRIPTION
Script was checking for binstall, but doing regular install anyway, even after trying to reinstall binstall. 

Just moved the conditional and umask around to use binstall if it's present. If it's not present, does a vanilla install instead of trying to install binstall first. 