### PR TITLE
umask needs to be before any cargo command

### DIFF
--- a/src/cargo-binstall/install.sh
+++ b/src/cargo-binstall/install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+umask 002
+
 PACKAGES=${PACKAGES:-""}
 
 CARGO_PACKAGES=("${PACKAGES//,/ }")
@@ -20,5 +22,4 @@ if [ -z "${PACKAGES}" ]; then
     exit 0
 fi
 
-umask 002
 cargo binstall -y --force --locked $CARGO_PACKAGES


### PR DESCRIPTION
Moving umask fixes an issue where cargo install would otherwise create files in `/usr/local/cargo` that are owned by root.

My dev container default has a user of vscode and that user now has no access to the files and cargo cannot install any packages used in my devcontainer.